### PR TITLE
Fix Counter test

### DIFF
--- a/packages/contracts/test/L2/Counter.ts
+++ b/packages/contracts/test/L2/Counter.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { StarknetContract } from "hardhat/types";
 
 describe("Counter", function () {
-  this.timeout(30_000);
+  this.timeout(50_000);
 
   let contract: StarknetContract;
 
@@ -17,7 +17,7 @@ describe("Counter", function () {
     expect(value).to.equal(10n);
   });
 
-  it.only("can increment by the given argument", async () => {
+  it("can increment by the given argument", async () => {
     await contract.invoke("increment", { inc: 5 });
 
     const { value } = await contract.call("read");


### PR DESCRIPTION
Me and another participant found that our tests timed out and we could fix it by increasing the timeout slightly. I'm also removing the `only` restriction which I think was unintended.