### PR TITLE
Dedupe and change submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "packages/contracts/openzeppelin-cairo"]
 	path = packages/contracts/openzeppelin_cairo
-	url = git@github.com:OpenZeppelin/cairo-contracts
-[submodule "packages/contracts/openzeppelin_cairo"]
-	path = packages/contracts/openzeppelin_cairo
-	url = git@github.com:OpenZeppelin/cairo-contracts
+	url = https://github.com/OpenZeppelin/cairo-contracts.git


### PR DESCRIPTION
There seems to be a duplicate entry for the OpenZeppelin Cairo contracts submodule.

This PR removes one entry and changes from the SSH to the HTTPS URL. Some participants (including me) didn't have an SSH key set up locally and got a permission error when running `git submodule init && git submodule update`.

The rationale being that the HTTPS URL will work for everyone.